### PR TITLE
Pin NumPy version to 1.18-1.24

### DIFF
--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -45,7 +45,7 @@ requirements:
   run:
     - python >=3.7
     # NumPy 1.22.0, 1.22.1, 1.22.2 are all broken for ufuncs, see #7756
-    - numpy >=1.18, !=1.22.0, !=1.22.1, !=1.22.2, <1.23
+    - numpy >=1.18, !=1.22.0, !=1.22.1, !=1.22.2, <1.24
     - setuptools
     - importlib_metadata       # [py<39]
     # On channel https://anaconda.org/numba/

--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -5,7 +5,7 @@ Installation
 Compatibility
 -------------
 
-Numba is compatible with Python 3.7--3.10, and Numpy versions 1.18 up to 1.22.
+Numba is compatible with Python 3.7--3.10, and Numpy versions 1.18 up to 1.23.
 
 Our supported platforms are:
 

--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -142,8 +142,8 @@ def _ensure_critical_deps():
 
     if numpy_version < (1, 18):
         raise ImportError("Numba needs NumPy 1.18 or greater")
-    elif numpy_version > (1, 22):
-        raise ImportError("Numba needs NumPy 1.22 or less")
+    elif numpy_version > (1, 23):
+        raise ImportError("Numba needs NumPy 1.23 or less")
 
     try:
         import scipy

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ min_python_version = "3.7"
 max_python_version = "3.11"  # exclusive
 min_numpy_build_version = "1.11"
 min_numpy_run_version = "1.18"
-max_numpy_run_version = "1.23"
+max_numpy_run_version = "1.24"
 min_llvmlite_version = "0.39.0dev0"
 max_llvmlite_version = "0.40"
 


### PR DESCRIPTION
Limit allowed NumPy versions for release